### PR TITLE
fix: tests: allow SIGURG in test runs

### DIFF
--- a/pkg/containerrun/containerrun_test.go
+++ b/pkg/containerrun/containerrun_test.go
@@ -403,6 +403,11 @@ var _ = Describe("Run", func() {
 				Signal(syscall.SIGCHLD).
 				Return(nil).
 				AnyTimes()
+			// Golang runtime internally raises SIGURG; we need to ignore them.
+			process.EXPECT().
+				Signal(syscall.SIGURG).
+				Return(nil).
+				AnyTimes()
 			runner := NewMockRunner(ctrl)
 			runner.EXPECT().
 				Run(command, stdio).
@@ -454,6 +459,11 @@ var _ = Describe("Run", func() {
 			// test case. We may receive them, or not.
 			process.EXPECT().
 				Signal(syscall.SIGCHLD).
+				Return(nil).
+				AnyTimes()
+			// Golang runtime internally raises SIGURG; we need to ignore them.
+			process.EXPECT().
+				Signal(syscall.SIGURG).
 				Return(nil).
 				AnyTimes()
 			runner := NewMockRunner(ctrl)
@@ -514,6 +524,11 @@ var _ = Describe("Run", func() {
 			// test case. We may receive them, or not.
 			process.EXPECT().
 				Signal(syscall.SIGCHLD).
+				Return(nil).
+				AnyTimes()
+			// Golang runtime internally raises SIGURG; we need to ignore them.
+			process.EXPECT().
+				Signal(syscall.SIGURG).
 				Return(nil).
 				AnyTimes()
 			runner := NewMockRunner(ctrl)
@@ -584,6 +599,11 @@ var _ = Describe("Run", func() {
 			// test case. We may receive them, or not.
 			process.EXPECT().
 				Signal(syscall.SIGCHLD).
+				Return(nil).
+				AnyTimes()
+			// Golang runtime internally raises SIGURG; we need to ignore them.
+			process.EXPECT().
+				Signal(syscall.SIGURG).
 				Return(nil).
 				AnyTimes()
 			runner := NewMockRunner(ctrl)
@@ -700,6 +720,11 @@ var _ = Describe("Run", func() {
 				Signal(syscall.SIGCHLD).
 				Return(nil).
 				AnyTimes()
+			// Golang runtime internally raises SIGURG; we need to ignore them.
+			process.EXPECT().
+				Signal(syscall.SIGURG).
+				Return(nil).
+				AnyTimes()
 			runner := NewMockRunner(ctrl)
 			runner.EXPECT().
 				Run(command, stdio).
@@ -801,6 +826,12 @@ var _ = Describe("ProcessRegistry", func() {
 			p3.EXPECT().Signal(sig).Return(nil)
 			p4.EXPECT().Signal(sig).Return(expectedErr)
 
+			// Golang runtime internally raises SIGURG; we need to ignore them.
+			p1.EXPECT().Signal(syscall.SIGURG).Return(nil).AnyTimes()
+			p2.EXPECT().Signal(syscall.SIGURG).Return(nil).AnyTimes()
+			p3.EXPECT().Signal(syscall.SIGURG).Return(nil).AnyTimes()
+			p4.EXPECT().Signal(syscall.SIGURG).Return(nil).AnyTimes()
+
 			errors := pr.SignalAll(sig)
 			Expect(errors).To(Equal([]error{expectedErr, expectedErr}))
 		})
@@ -817,6 +848,10 @@ var _ = Describe("ProcessRegistry", func() {
 			p1.EXPECT().Signal(sig).Return(nil)
 			p2.EXPECT().Signal(sig).Return(nil)
 
+			// Golang runtime internally raises SIGURG; we need to ignore them.
+			p1.EXPECT().Signal(syscall.SIGURG).Return(nil).AnyTimes()
+			p2.EXPECT().Signal(syscall.SIGURG).Return(nil).AnyTimes()
+			
 			errors := pr.SignalAll(sig)
 			Expect(errors).To(Equal([]error{}))
 		})


### PR DESCRIPTION
Golang runtime 1.14+ will internally raise `SIGURG` for their own purposes; when we see this, we end up passing it down into the child process.  As there's no way to tell if that's from the runtime or from the system, we'll blindly pass it in and hope for the best.  In that case, though, we should expect them to show up in the test; otherwise we'll get flaky tests as they panic when the mock processes receive an unexpected signal.

This was documented very vaguely in the [golang 1.14 release notes](https://tip.golang.org/doc/go1.14#runtime), but the real documentation is in https://github.com/golang/go/issues/37942 instead.

From testing, it appears that calling [`signal.Ignore()`](https://pkg.go.dev/os/signal@go1.15.4#Ignore) in a `BeforeSuite` has no effect; it needs to be done after the [`signal.Notify()`](https://pkg.go.dev/os/signal@go1.15.4#Notify).

I'm also happy to change it to a [`signal.Ignore()`](https://pkg.go.dev/os/signal@go1.15.4#Ignore) call inside of [`Run()`](https://github.com/cloudfoundry-incubator/quarks-container-run/blob/18cdd436ebadac8a8696d4ed75ab6535e7cc1ffe/pkg/containerrun/containerrun.go#L74), if never passing `SIGURG` down to the child process is preferred; however, this will include any such signals from outside the go runtime.